### PR TITLE
Fix crash when type comment appears on continuation line

### DIFF
--- a/src/com2ann.py
+++ b/src/com2ann.py
@@ -374,7 +374,18 @@ def process_assign(comment: AssignData, data: FileData,
 
     rv_end = comment.rvalue_end_line - 1
     rv_start = comment.rvalue_start_line - 1
-    lines[rv_end] = strip_type_comment(lines[rv_end])
+    if re.search(TYPE_COM, lines[rv_end]):
+        lines[rv_end] = strip_type_comment(lines[rv_end])
+    else:
+        # Special case: type comment moved to a separate continuation line.
+        assert lines[rv_end].rstrip().endswith('\\')
+        lines[rv_end + 1] = strip_type_comment(lines[rv_end + 1])
+        if not lines[rv_end + 1].strip():
+            del lines[rv_end + 1]
+            # Also remove the \ symbol from the previous line.
+            trailer = re.search(_TRAILER, lines[rv_end])
+            assert trailer
+            lines[rv_end] = lines[rv_end].rstrip()[:-1].rstrip() + trailer.group()
 
     if comment.tuple_rvalue:
         # TODO: take care of (1, 2), (3, 4) with matching pars.

--- a/src/com2ann.py
+++ b/src/com2ann.py
@@ -378,7 +378,8 @@ def process_assign(comment: AssignData, data: FileData,
         lines[rv_end] = strip_type_comment(lines[rv_end])
     else:
         # Special case: type comment moved to a separate continuation line.
-        assert lines[rv_end].rstrip().endswith('\\')
+        assert (lines[rv_end].rstrip().endswith('\\') or
+                lines[rv_end + 1].lstrip().startswith(')'))
         lines[rv_end + 1] = strip_type_comment(lines[rv_end + 1])
         if not lines[rv_end + 1].strip():
             del lines[rv_end + 1]

--- a/src/test_com2ann.py
+++ b/src/test_com2ann.py
@@ -172,6 +172,33 @@ class AssignTestCase(BaseTestCase):
         self.check("x = None  # type: Optional[Literal['#']]",
                    "x: Optional[Literal['#']] = None")
 
+    def test_comment_on_separate_line(self) -> None:
+        self.check(
+            """
+            bar = {} \\
+                # type: SuperLongType[WithArgs]
+            """,
+            """
+            bar: SuperLongType[WithArgs] = {}
+            """)
+        self.check(
+            """
+            bar = {} \\
+                # type: SuperLongType[WithArgs]  # noqa
+            """,
+            """
+            bar: SuperLongType[WithArgs] = {} \\
+                # noqa
+            """)
+        self.check(
+            """
+            bar = None \\
+                # type: SuperLongType[WithArgs]
+            """,
+            """
+            bar: SuperLongType[WithArgs]
+            """, n=True)
+
 
 class FunctionTestCase(BaseTestCase):
     def test_single(self) -> None:

--- a/src/test_com2ann.py
+++ b/src/test_com2ann.py
@@ -199,6 +199,34 @@ class AssignTestCase(BaseTestCase):
             bar: SuperLongType[WithArgs]
             """, n=True)
 
+    def test_continuation_using_parens(self) -> None:
+        self.check(
+            """
+            X = (
+                {one}
+                | {other}
+            )  # type: Final  # another option
+            """,
+            """
+            X: Final = (
+                {one}
+                | {other}
+            )  # another option
+            """)
+        self.check(
+            """
+            X = (  # type: ignore
+                {one}
+                | {other}
+            )  # type: Final
+            """,
+            """
+            X: Final = (  # type: ignore
+                {one}
+                | {other}
+            )
+            """)
+
 
 class FunctionTestCase(BaseTestCase):
     def test_single(self) -> None:


### PR DESCRIPTION
Fixes #10 

The fix may be a bit ad hoc, but IMO it covers 99% of cases for an already rare scenario.