### PR TITLE
Fix type comment left on separate continuation line after a type ignore of expression line

### DIFF
--- a/src/com2ann.py
+++ b/src/com2ann.py
@@ -467,7 +467,8 @@ def process_assign(comment: AssignData, data: FileData,
     # We perform the tasks in order from larger line/columns to smaller ones
     # to avoid shuffling the line column numbers in following code.
     # First remove the type comment.
-    if re.search(TYPE_COM, lines[rv_end]):
+    match = re.search(TYPE_COM, lines[rv_end])
+    if match and not match.group(1).lstrip().startswith('ignore'):
         lines[rv_end] = strip_type_comment(lines[rv_end])
     else:
         # Special case: type comment moved to a separate continuation line.

--- a/src/test_com2ann.py
+++ b/src/test_com2ann.py
@@ -228,6 +228,23 @@ class AssignTestCase(BaseTestCase):
                 | {other}
             )
             """)
+        self.check(
+            """
+            foo = object()
+
+            bar = (
+                # Comment which explains why this ignored
+                foo.quox   # type: ignore[attribute]
+            )  # type: Mapping[str, Distribution]
+            """,
+            """
+            foo = object()
+
+            bar: Mapping[str, Distribution] = (
+                # Comment which explains why this ignored
+                foo.quox   # type: ignore[attribute]
+            )
+            """)
 
     def test_with_for(self) -> None:
         self.check(


### PR DESCRIPTION
Fixes #34 